### PR TITLE
Run builds without docker volume

### DIFF
--- a/app/jobs/build_job.rb
+++ b/app/jobs/build_job.rb
@@ -49,9 +49,9 @@ class BuildJob < ApplicationJob
 
       # deploy images
       group_id = SecureRandom.uuid
-      Dir["*.*.image"].each do |file|
+      Dir["#{tmpdir}/*.*.image"].each do |file|
         logger.info "build ##{build_id}: deploying #{file}"
-        DeployService.new.deploy(build.app, group_id, file, File.open(file), build.tag)
+        DeployService.new.deploy(build.app, group_id, file, File.open(file, 'rb'), build.tag)
       end
     end
   end


### PR DESCRIPTION
### Issues

* The volume in the tmpdir does not work properly on the Linux machine.
  - I don't know why, but it seems a problem with permissions.
* The volume does not work properly if the docker daemon is running in the different host.
  - This is similar to the Boot2docker's case.

### Changes

* Use `docker cp` instead of the volume.